### PR TITLE
chore: bump libarchive to 3.7.2.bcr.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 bazel_dep(name = "aspect_bazel_lib", version = "2.5.3")
-bazel_dep(name = "libarchive", version = "3.7.2.bcr.2")
+bazel_dep(name = "libarchive", version = "3.7.2.bcr.3")
 bazel_dep(name = "hermetic_cc_toolchain", version = "3.0.1")
 
 toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")


### PR DESCRIPTION
Picks up a fix that is the root cause of https://github.com/aspect-build/rules_js/issues/1597