### PR TITLE
fix: build with older windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,14 +46,10 @@ jobs:
       - uses: actions/checkout@v4
       - run: |
           bazel build @libarchive//tar
-          mv bazel-bin/external/libarchive~/tar/bsdtar tar_windows_amd64
-      - name: smoke test
-        run: |
-          .\tar_windows_amd64 --help
+          mv bazel-bin/external/libarchive~/tar/bsdtar tar_windows_amd64.exe
       - uses: actions/upload-artifact@v4
         id: upload
         with:
           name: windows
           retention-days: 1
-          path: |
-            tar_windows_amd64
+          path: tar_windows_amd64.exe

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
             tar_linux_amd64
   build_windows:
     name: windows
-    runs-on: windows-2022
+    runs-on: windows-2019
     outputs:
       artifact: ${{steps.upload.outputs.artifact-url}}
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2022-01-11-github-actions-jobs-running-on-windows-latest-are-now-running-on-windows-server-2022/

maybe fix https://github.com/bazel-contrib/bazel-lib/actions/runs/10913031190/job/30288841216