### PR TITLE
Remove "non-Windows" from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This repository builds binary releases for bsdtar.
 
 It's a workaround for https://github.com/libarchive/libarchive/releases not including
-non-Windows binaries in the releases.
+binaries in the releases.
 
 It is built using the Bazel module at https://registry.bazel.build/modules/libarchive
 using a musl toolchain from https://registry.bazel.build/modules/hermetic_cc_toolchain


### PR DESCRIPTION
libarchive doesn't supply pre-build binaries for any OS anymore.

By the way, it would be good to have GitHub Actions automatically do a release on this repo whenever they add one.